### PR TITLE
Add support for Scala.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,12 @@ jobs:
   build:
     name: Build and Test
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         scala: [3.0.0]
         java: [adopt@1.8]
+        platform: [jvm, js]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -53,7 +55,12 @@ jobs:
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Validate JVM
+        if: matrix.platform == 'jvm'
         run: sbt ++${{ matrix.scala }} validateJVM
+
+      - name: Validate JS
+        if: matrix.platform == 'js'
+        run: sbt ++${{ matrix.scala }} validateJS
 
   publish:
     name: Publish Artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
-
 val dottyVersion = "3.0.0"
 
 ThisBuild / organization := "org.typelevel"

--- a/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
@@ -263,7 +263,7 @@ object Foldable {
     def foldRight[A, B](fa: F[A])(lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
       inst.foldRight[A, Eval[B]](fa)(lb)(
         [t[_]] => (fd: Foldable[t], t0: t[A], acc: Eval[B]) =>
-          Continue(acc.flatMap(acc0 => fd.foldRight(t0)(Eval.now(acc0))(f)))
+          Continue(Eval.defer(fd.foldRight(t0)(acc)(f)))
       )
 
   given foldableCoproduct[F[_]](using inst: => K1.CoproductInstances[Foldable, F]): Foldable[F] with
@@ -274,7 +274,7 @@ object Foldable {
 
     def foldRight[A, B](fa: F[A])(lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
       inst.fold[A, Eval[B]](fa)(
-        [t[_]] => (fd: Foldable[t], t0: t[A]) => lb.flatMap(lb0 => fd.foldRight(t0)(Eval.now(lb0))(f))
+        [t[_]] => (fd: Foldable[t], t0: t[A]) => Eval.defer(fd.foldRight(t0)(lb)(f))
       )
 
   inline def derived[F[_]](using gen: K1.Generic[F]): Foldable[F] =

--- a/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
@@ -19,6 +19,8 @@ package shapeless3.deriving
 import scala.annotation.tailrec
 import scala.compiletime._
 
+import cats.Eval
+
 // Type classes
 
 trait Monoid[A] {
@@ -232,53 +234,6 @@ object Traverse {
    inline def derived[F[_]](using gen: K1.Generic[F]): Traverse[F] = traverseGen
 }
 
-//Encodes lazy evaluation for the sake of Foldable#foldRight
-sealed trait Eval[A] {
-
-  def map[B](f: A => B): Eval[B] = flatMap(f.andThen(Eval.now(_)))
-
-  def flatMap[B](f: A => Eval[B]): Eval[B] = Bind(this, f)
-
-  //Simplistic, no error handling, etc, etc
-  def force: A = {
-    var stack: List[Any => Eval[Any]] = Nil
-
-    @tailrec
-    def go(e: Eval[Any]): Any =
-      e match {
-        case Now(a) => stack match {
-          case Nil => a
-          case k :: ks => {
-            stack = ks
-            go(k(a))
-          }
-        }
-        case Later(thunk) => stack match {
-          case Nil => thunk()
-          case k :: ks => {
-            stack = ks
-            go(k(thunk()))
-          }
-        }
-        case Bind(e, f) => {
-          stack = f.asInstanceOf :: stack
-          go(e.asInstanceOf)
-        }
-      }
-
-    go(this.asInstanceOf[Eval[Any]]).asInstanceOf[A]
-  }
-}
-case class Now[A](a: A) extends Eval[A]
-case class Later[A](thunk: () => A) extends Eval[A]
-case class Bind[X, A](ev: Eval[X], f: X => Eval[A]) extends Eval[A]
-
-object Eval {
-  def now[A](value: A): Eval[A] = Now(value)
-
-  def later[A](thunk: => A): Eval[A] = Later(() => thunk)
-}
-
 trait Foldable[F[_]] {
   def foldLeft[A, B](fa: F[A])(b: B)(f: (B, A) => B): B
 
@@ -307,7 +262,8 @@ object Foldable {
 
     def foldRight[A, B](fa: F[A])(lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
       inst.foldRight[A, Eval[B]](fa)(lb)(
-        [t[_]] => (fd: Foldable[t], t0: t[A], acc: Eval[B]) => Continue(fd.foldRight(t0)(acc)(f))
+        [t[_]] => (fd: Foldable[t], t0: t[A], acc: Eval[B]) =>
+          Continue(acc.flatMap(acc0 => fd.foldRight(t0)(Eval.now(acc0))(f)))
       )
 
   given foldableCoproduct[F[_]](using inst: => K1.CoproductInstances[Foldable, F]): Foldable[F] with
@@ -318,7 +274,7 @@ object Foldable {
 
     def foldRight[A, B](fa: F[A])(lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
       inst.fold[A, Eval[B]](fa)(
-        [t[_]] => (fd: Foldable[t], t0: t[A]) => fd.foldRight(t0)(lb)(f)
+        [t[_]] => (fd: Foldable[t], t0: t[A]) => lb.flatMap(lb0 => fd.foldRight(t0)(Eval.now(lb0))(f))
       )
 
   inline def derived[F[_]](using gen: K1.Generic[F]): Foldable[F] =

--- a/modules/typeable/src/main/scala/shapeless3/typeable/typeable.scala
+++ b/modules/typeable/src/main/scala/shapeless3/typeable/typeable.scala
@@ -33,7 +33,7 @@ trait Typeable[T] extends Serializable {
 
 object syntax {
   object typeable {
-    implicit class Ops[T](t: T) {
+    extension [T](t: T) {
       /**
        * Cast the receiver to a value of type `U` if possible. This operation
        * will be as precise wrt erasure as possible given the in-scope
@@ -64,7 +64,7 @@ object syntax {
 object Typeable extends Typeable0 {
   import java.{ lang => jl }
   import scala.reflect.ClassTag
-  import syntax.typeable.given
+  import syntax.typeable.*
 
   inline def apply[T](using tt: Typeable[T]): Typeable[T] = tt
 
@@ -91,8 +91,32 @@ object Typeable extends Typeable0 {
   /** Typeable instance for `Unit`. */
   given unitTypeable: Typeable[Unit] = ValueTypeable[Unit, scala.runtime.BoxedUnit](classOf[scala.runtime.BoxedUnit], "Unit")
 
+  /** Typeable instance for `java.lang.Byte`. */
+  given jlByteTypeable: Typeable[jl.Byte] = ValueTypeable[jl.Byte, jl.Byte](classOf[jl.Byte], "java.lang.Byte")
+  /** Typeable instance for `java.lang.Short`. */
+  given jlShortTypeable: Typeable[jl.Short] = ValueTypeable[jl.Short, jl.Short](classOf[jl.Short], "java.lang.Short")
+  /** Typeable instance for `java.lang.Character`. */
+  given jlCharacterTypeable: Typeable[jl.Character] = ValueTypeable[jl.Character, jl.Character](classOf[jl.Character], "java.lang.Character")
+  /** Typeable instance for `java.lang.Integer`. */
+  given jlIntegerTypeable: Typeable[jl.Integer] = ValueTypeable[jl.Integer, jl.Integer](classOf[jl.Integer], "java.lang.Integer")
+  /** Typeable instance for `java.lang.Long`. */
+  given jlLongTypeable: Typeable[jl.Long] = ValueTypeable[jl.Long, jl.Long](classOf[jl.Long], "java.lang.Long")
+  /** Typeable instance for `java.lang.Float`. */
+  given jlFloatTypeable: Typeable[jl.Float] = ValueTypeable[jl.Float, jl.Float](classOf[jl.Float], "java.lang.Float")
+  /** Typeable instance for `java.lang.Double`. */
+  given jlDoubleTypeable: Typeable[jl.Double] = ValueTypeable[jl.Double, jl.Double](classOf[jl.Double], "java.lang.Double")
+  /** Typeable instance for `java.lang.Boolean`. */
+  given jlBooleanTypeable: Typeable[jl.Boolean] = ValueTypeable[jl.Boolean, jl.Boolean](classOf[jl.Boolean], "java.lang.Boolean")
+  /** Typeable instance for `scala.runtime.BoxedUnit`. */
+  given srBoxedUnitTypeable: Typeable[scala.runtime.BoxedUnit] = ValueTypeable[scala.runtime.BoxedUnit, scala.runtime.BoxedUnit](classOf[scala.runtime.BoxedUnit], "scala.runtime.BoxedUnit")
+
   def isAnyValClass[T](clazz: Class[T]) =
-    (classOf[jl.Number] isAssignableFrom clazz) ||
+    clazz == classOf[jl.Byte] ||
+    clazz == classOf[jl.Short] ||
+    clazz == classOf[jl.Integer] ||
+    clazz == classOf[jl.Long] ||
+    clazz == classOf[jl.Float] ||
+    clazz == classOf[jl.Double] ||
     clazz == classOf[jl.Boolean] ||
     clazz == classOf[jl.Character] ||
     clazz == classOf[scala.runtime.BoxedUnit]
@@ -412,7 +436,7 @@ trait TypeCase[T] extends Serializable {
 }
 
 object TypeCase {
-  import syntax.typeable.given
+  import syntax.typeable.*
   def apply[T](using tt: Typeable[T]): TypeCase[T] =
     new TypeCase[T] {
       def unapply(t: Any): Option[T] = t.cast[T]

--- a/modules/typeable/src/test/scala/shapeless3/typeable/typeable.scala
+++ b/modules/typeable/src/test/scala/shapeless3/typeable/typeable.scala
@@ -22,7 +22,7 @@ class TypeableTests {
   import org.junit.Test
   import org.junit.Assert._
 
-  import syntax.typeable.given
+  import syntax.typeable.*
   import shapeless3.test._
 
   @Test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
-addSbtPlugin("com.geirsson"   % "sbt-ci-release"     % "1.5.7")
-addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.10.1")
+addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.7")
+addSbtPlugin("com.codecommit"     % "sbt-github-actions"       % "0.10.1")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.5.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
This is mainly the addition of Scala.js build/publish infrastructure, however building for Scala.js revealed a couple of issues.

+ The handling of boxed primitives for `Typeable` was missing some instances which was only apparent when the corresponding tests failed for js.
+ The mini `Eval` that @TimWSpence put together for `Foldable#foldRight` test derivation blew up on js. When that was swapped out for a test dependency on cats-core it _still_ failed, revealing that the use of `Eval` in the `Foldable` derivation was incorrect (a missing `flatMap`). This will also be an issue with the prototype `Foldable` implementation in Kittens for Scala 3.