### PR TITLE
Added project to ProductInstances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core.{ProblemFilters, ReversedMissingMethodProblem}
+
 val dottyVersion = "3.0.0"
 
 ThisBuild / organization := "org.typelevel"
@@ -82,6 +84,11 @@ lazy val deriving = crossProject(JSPlatform, JVMPlatform)
   )
   .settings(commonSettings)
   .settings(mimaSettings)
+  .settings(
+     mimaBinaryIssueFilters ++= Seq(
+       ProblemFilters.exclude[ReversedMissingMethodProblem]("shapeless3.deriving.internals.ErasedProductInstances.erasedProject")
+     )
+   )
   .settings(publishSettings)
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
 

--- a/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
@@ -37,6 +37,7 @@ private[shapeless3] abstract class ErasedProductInstances[K, FT] extends ErasedI
   def erasedFoldLeft2(x0: Any, y0: Any)(a: Any)(f: (Any, Any, Any, Any) => CompleteOr[Any]): Any
   def erasedFoldRight(x0: Any)(a: Any)(f: (Any, Any, Any) => CompleteOr[Any]): Any
   def erasedFoldRight2(x0: Any, y0: Any)(a: Any)(f: (Any, Any, Any, Any) => CompleteOr[Any]): Any
+  def erasedProject(x0: Any)(p: Int)(f: (Any, Any) => Any): Any
 }
 
 private[shapeless3] final class ErasedProductInstances1[K, FT](val mirror: Mirror.Product, i: Any) extends ErasedProductInstances[K, FT] {
@@ -89,6 +90,9 @@ private[shapeless3] final class ErasedProductInstances1[K, FT](val mirror: Mirro
       case acc => acc
     }
   }
+
+  final def erasedProject(x0: Any)(p: Int)(f: (Any, Any) => Any): Any =
+    f(i, toProduct(x0).productElement(0))
 }
 
 private[shapeless3] final class ErasedProductInstancesN[K, FT](val mirror: Mirror.Product, is: Array[Any]) extends ErasedProductInstances[K, FT] {
@@ -257,6 +261,8 @@ private[shapeless3] final class ErasedProductInstancesN[K, FT](val mirror: Mirro
     }
   }
 
+  final def erasedProject(x0: Any)(p: Int)(f: (Any, Any) => Any): Any =
+    f(is(p), toProduct(x0).productElement(p))
 }
 
 private[shapeless3] object ErasedProductInstances {

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -106,6 +106,8 @@ object K0 {
       inst.erasedFoldRight(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldRight2[Acc](x: T, y: T)(i: Acc)(f: [t] => (F[t], t, t, Acc) => CompleteOr[Acc]): Acc =
       inst.erasedFoldRight2(x, y)(i)(f.asInstanceOf).asInstanceOf
+    inline def project[R](t: T)(p: Int)(f: [t] => (F[t], t) => R): R =
+      inst.erasedProject(t)(p)(f.asInstanceOf).asInstanceOf
 
   extension [F[_], T](inst: CoproductInstances[F, T])
     inline def project[Acc](p: Int)(i: Acc)(f: [t] => (Acc, F[t]) => (Acc, Option[t])): (Acc, Option[T]) =
@@ -201,6 +203,8 @@ object K1 {
       inst.erasedFoldRight(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldRight2[A, B, Acc](x: T[A], y: T[B])(i: Acc)(f: [t[_]] => (F[t], t[A], t[B], Acc) => CompleteOr[Acc]): Acc =
       inst.erasedFoldRight2(x, y)(i)(f.asInstanceOf).asInstanceOf
+    inline def project[A, R](t: T[A])(p: Int)(f: [t[_]] => (F[t], t[A]) => R): R =
+      inst.erasedProject(t)(p)(f.asInstanceOf).asInstanceOf
 
   extension [F[_[_]], T[_]](inst: CoproductInstances[F, T])
     inline def fold[A, R](x: T[A])(f: [t[_]] => (F[t], t[A]) => R): R =
@@ -296,6 +300,8 @@ object K11 {
       inst.erasedFoldRight(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldRight2[A[_], B[_], Acc](x: T[A], y: T[B])(i: Acc)(f: [t[_[_]]] => (F[t], t[A], t[B], Acc) => CompleteOr[Acc]): Acc =
       inst.erasedFoldRight2(x, y)(i)(f.asInstanceOf).asInstanceOf
+    inline def project[A[_], R](t: T[A])(p: Int)(f: [t[_[_]]] => (F[t], t[A]) => R): R =
+      inst.erasedProject(t)(p)(f.asInstanceOf).asInstanceOf
 
   extension [F[_[_[_]]], T[_[_]]](inst: CoproductInstances[F, T])
     inline def fold[A[_], R](x: T[A])(f: [t[_[_]]] => (F[t], t[A]) => R): R =
@@ -390,6 +396,8 @@ object K2 {
       inst.erasedFoldRight(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldRight2[A, B, C, D, Acc](x: T[A, B], y: T[C, D])(i: Acc)(f: [t[_, _]] => (F[t], t[A, B], t[C, D], Acc) => CompleteOr[Acc]): Acc =
       inst.erasedFoldRight2(x, y)(i)(f.asInstanceOf).asInstanceOf
+    inline def project[A, B, R](t: T[A, B])(p: Int)(f: [t[_, _]] => (F[t], t[A, B]) => R): R =
+      inst.erasedProject(t)(p)(f.asInstanceOf).asInstanceOf
 
   extension [F[_[_, _]], T[_, _]](inst: CoproductInstances[F, T])
     inline def fold[A, B, R](x: T[A, B])(f: [t[_, _]] => (F[t], t[A, B]) => R): R =

--- a/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
@@ -526,15 +526,12 @@ object Show {
   given Show[Boolean] = (_: Boolean).toString
 
   given showGen[T](using inst: K0.ProductInstances[Show, T], labelling: Labelling[T]): Show[T] with {
-    def show(t: T): String = {
+    def show(t: T): String =
       if(labelling.elemLabels.isEmpty) labelling.label
-      else {
-        val elems: List[String] = inst.foldLeft(t)(List.empty[String])(
-          [t] => (acc: List[String], st: Show[t], t: t) => Continue(st.show(t) :: acc)
-        )
-        labelling.elemLabels.zip(elems.reverse).map((k, v) => s"$k: $v").mkString(s"${labelling.label}(", ", ", ")")
-      }
-    }
+      else
+        labelling.elemLabels.zipWithIndex.map(
+          (label, i) => s"$label: ${inst.project(t)(i)([t] => (st: Show[t], pt: t) => st.show(pt))}"
+        ).mkString(s"${labelling.label}(", ", ", ")")
   }
 
   given showGenC[T](using inst: => K0.CoproductInstances[Show, T]): Show[T] with {


### PR DESCRIPTION
Adds a new operation `project` to `Kn` allowing an element of a product to be projected out, paired with its corresponding type class instance. This allows products to be manipulated partially and/or incrementally.

As an aside the similar looking method on `CoproductInstances` should probably have been called `inject`.