### PR TITLE
Replace unsound `summonFirst` with sound alternative

### DIFF
--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -60,6 +60,7 @@ object K0 {
       case _ => EmptyTuple
     }
 
+  @deprecated("unsound - use .withFirst on CoproductGeneric or `summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]`", "3.0.2")
   inline def summonFirst[F[_], T, U]: F[U] = summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
 
   transparent inline def summonFirst0[T]: Any = inline erasedValue[T] match {
@@ -76,6 +77,7 @@ object K0 {
   extension [T](gen: CoproductGeneric[T])
     inline def toRepr(o: T): Union[gen.MirroredElemTypes] = o.asInstanceOf
     inline def fromRepr(r: Union[gen.MirroredElemTypes]): T = r.asInstanceOf
+    inline def withFirst[F[_], R](f: [t <: T] => F[t] => R): R = (f.asInstanceOf[Any => R])(summonFirst0[LiftP[F, gen.MirroredElemTypes]])
 
   extension [F[_], T](gen: Generic[T])
     inline def derive(f: => (ProductGeneric[T] & gen.type) ?=> F[T], g: => (CoproductGeneric[T] & gen.type) ?=> F[T]): F[T] =
@@ -172,6 +174,7 @@ object K1 {
       case _ => EmptyTuple
     }
 
+  @deprecated("unsound - use .withFirst on CoproductGeneric or `summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]`", "3.0.2")
   inline def summonFirst[F[_[_]], T[_], U[_]]: F[U] = summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
 
   transparent inline def summonFirst0[T]: Any = inline erasedValue[T] match {
@@ -188,6 +191,7 @@ object K1 {
   extension [T[_], A](gen: CoproductGeneric[T])
     inline def toRepr(o: T[A]): Union[gen.MirroredElemTypes[A]] = o.asInstanceOf
     inline def fromRepr(r: Union[gen.MirroredElemTypes[A]]): T[A] = r.asInstanceOf
+    inline def withFirst[F[_[_]], R](f: [t[x] <: T[x]] => F[t] => R): R = (f.asInstanceOf[Any => R])(summonFirst0[LiftP[F, gen.MirroredElemTypes]])
 
   extension [F[_[_]], T[_]](gen: Generic[T]) inline def derive(f: => (ProductGeneric[T] & gen.type) ?=> F[T], g: => (CoproductGeneric[T] & gen.type) ?=> F[T]): F[T] =
     inline gen match {

--- a/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
@@ -426,7 +426,7 @@ object Empty {
     mkEmpty(inst.construct([a] => (ma: Empty[a]) => ma.empty))
 
   inline given emptyGenC[A](using gen: K0.CoproductGeneric[A]): Empty[A] =
-    mkEmpty(K0.summonFirst[Empty, gen.MirroredElemTypes, A].empty)
+    mkEmpty(gen.withFirst[Empty, A]([a <: A] => (_: Empty[a]).empty))
 
   inline def derived[A](using gen: K0.Generic[A]): Empty[A] =
     gen.derive(emptyGen, emptyGenC)
@@ -452,7 +452,7 @@ object EmptyK {
     mkEmptyK([t] => () => inst.construct([f[_]] => (ef: EmptyK[f]) => ef.empty[t]))
 
   inline given emptyKGenC[A[_]](using gen: K1.CoproductGeneric[A]): EmptyK[A] =
-    mkEmptyK[A]([t] => () => K1.summonFirst[EmptyK, gen.MirroredElemTypes, A].empty[t])
+    mkEmptyK[A]([t] => () => gen.withFirst[EmptyK, A[t]]([a[x] <: A[x]] => (_: EmptyK[a]).empty[t]))
 
   inline def derived[A[_]](using gen: K1.Generic[A]): EmptyK[A] =
     inline gen match {
@@ -500,7 +500,7 @@ object Pure {
     mkPure[A]([t] => (a: t) => inst.construct([f[_]] => (af: Alt1.Of[Pure, EmptyK][f]) => af.fold[f[t]](_.pure(a))(_.empty[t])))
 
   inline given pureGenC[A[_]](using gen: K1.CoproductGeneric[A]): Pure[A] =
-    mkPure[A]([t] => (a: t) => K1.summonFirst[Pure, gen.MirroredElemTypes, A].pure(a))
+    mkPure[A]([t] => (a: t) => gen.withFirst[Pure, A[t]]([f[x] <: A[x]] => (_: Pure[f]).pure(a)))
 
   inline def derived[A[_]](using gen: K1.Generic[A]): Pure[A] =
     inline gen match {


### PR DESCRIPTION
I think users expect the public API of Shapeless to be type-safe, but `summonFirst` does a cast that isn't in general correct (e.g. it would happily widen `Extract[Some]` to `Extract[Option]`). 

I tried to write a sound version but I think it would require Shapeless 2 style typeclass-based dependent typing, so I'm not sure it's worth it.

This doesn't cover `K11` and `K2` - I'll add them if this is approved in principle.