### PR TITLE
Fix embarrassing traverse bugs 🙈 

### DIFF
--- a/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
@@ -160,7 +160,7 @@ private[shapeless3] final class ErasedProductInstancesN[K, FT](val mirror: Mirro
 
   final def erasedTraverse(x0: Any)(map: (Any, Any) => Any)(pure: Any => Any)(ap: (Any, Any) => Any)(f: (Any, Any) => Any) = {
     val n = is.length
-    if (n == 0) x0
+    if (n == 0) pure(x0)
     else {
       val x = toProduct(x0)
       val arr = new Array[Any](n)

--- a/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
@@ -167,7 +167,8 @@ private[shapeless3] final class ErasedProductInstancesN[K, FT](val mirror: Mirro
       var acc = pure(())
       var i = 0
       while(i < n) {
-        acc = ap(map(acc, (_: Unit) => arr.update(i, _)), f(is(i), x.productElement(i)))
+        val j = i // avoid capturing `i` when the applicative is lazy
+        acc = ap(map(acc, (_: Unit) => arr.update(j, _)), f(is(j), x.productElement(j)))
         i = i+1
       }
       map(acc, (_: Unit) => mirror.fromProduct(new ArrayProduct(arr)))

--- a/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
@@ -65,4 +65,6 @@ object adts {
   case object NilF extends ListF[Nothing, Nothing]
 
   case class BI(b: Boolean, i: Int)
+  
+  case class Phantom[A]()
 }

--- a/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
@@ -38,6 +38,10 @@ object adts {
   sealed trait CList[+A] derives Eq, Show, Read, Functor, EmptyK, Traverse, Foldable
   case class CCons[+A](hd: A, tl: CList[A]) extends CList[A]
   case object CNil extends CList[Nothing]
+  object CList {
+    def apply[A](x: A, xs: A*): CCons[A] =
+      CCons(x, xs.foldRight[CList[A]](CNil)(CCons.apply))
+  }
 
   case class Order[F[_]](
     item: F[String],

--- a/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
@@ -235,6 +235,9 @@ class DerivationTests {
     val v7 = Traverse[OptE]
     assert(v7.traverse(SmE(1))((x: Int) => List(x + 1)) == List(SmE(2)))
     assert(v7.traverse(NnE)((x: Int) => List(x + 1)) == List(NnE))
+
+    val v8 = Traverse[Phantom]
+    assert(v8.traverse(Phantom())(Option(_)) == Some(Phantom()))
   }
 
 

--- a/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
@@ -225,20 +225,21 @@ class DerivationTests {
     assert(v3.traverse(Nn)((x: Int) => List(x + 1)) == List(Nn))
 
     val v4 = Traverse[Const[CNil.type]]
-    assert(v4.traverse(CNil)(Option(_)) == Some(CNil))
+    assert(v4.traverse(CNil)(Option.apply) == Some(CNil))
     val v5 = Traverse[CCons]
-    assert(v5.traverse(CCons("foo", CCons("bar", CNil)))(Option(_)) == Some(CCons("foo", CCons("bar", CNil))))
+    assert(v5.traverse(CList("foo", "bar"))(Option.apply) == Some(CList("foo", "bar")))
     val v6 = Traverse[CList]
-    assert(v6.traverse(CCons("foo", CCons("bar", CNil)))(Option(_)) == Some(CCons("foo", CCons("bar", CNil))))
-    assert(v6.traverse(CNil)(Option(_)) == Some(CNil))
-    assert(v6.traverse(CCons("foo", CCons("bar", CNil)))(() => _).apply() == CCons("foo", CCons("bar", CNil)))
+    assert(v6.traverse(CList("foo", "bar"))(Option.apply) == Some(CList("foo", "bar")))
+    assert(v6.traverse(CNil)(Option.apply) == Some(CNil))
+    assert(v6.traverse(CList("foo", "bar"))(() => _).apply() == CList("foo", "bar"))
+    assert(v6.traverse(CList(1, 2))(x => List(x, x + 1)) == List(CList(1, 2), CList(1, 3), CList(2, 2), CList(2, 3)))
 
     val v7 = Traverse[OptE]
     assert(v7.traverse(SmE(1))((x: Int) => List(x + 1)) == List(SmE(2)))
     assert(v7.traverse(NnE)((x: Int) => List(x + 1)) == List(NnE))
 
     val v8 = Traverse[Phantom]
-    assert(v8.traverse(Phantom())(Option(_)) == Some(Phantom()))
+    assert(v8.traverse(Phantom())(Option.apply) == Some(Phantom()))
   }
 
 

--- a/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
@@ -231,6 +231,7 @@ class DerivationTests {
     val v6 = Traverse[CList]
     assert(v6.traverse(CCons("foo", CCons("bar", CNil)))(Option(_)) == Some(CCons("foo", CCons("bar", CNil))))
     assert(v6.traverse(CNil)(Option(_)) == Some(CNil))
+    assert(v6.traverse(CCons("foo", CCons("bar", CNil)))(() => _).apply() == CCons("foo", CCons("bar", CNil)))
 
     val v7 = Traverse[OptE]
     assert(v7.traverse(SmE(1))((x: Int) => List(x + 1)) == List(SmE(2)))

--- a/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
@@ -201,6 +201,11 @@ object Applicative {
         f <- ff
         a <- fa
       } yield f(a)
+
+  given Applicative[[A] =>> () => A] with
+    def map[A, B](fa: () => A)(f: A => B): () => B = () => f(fa())
+    def pure[A](a: A): () => A = () => a
+    def ap[A, B](ff: () => A => B)(fa: () => A): () => B = () => ff()(fa())
 }
 
 trait Traverse[F[_]] extends Functor[F] {


### PR DESCRIPTION
This fixes 3 bugs in `traverse`:
  1. For an empty product we have to still wrap it in `pure`.
      This wasn't caught because case objects are covered by `Const`.
  2. We were capturing the mutable variable `i` when the `Applicative` is lazy.
  3. We cannot use a mutable `Array` as an accumulator, e.g. when the `Applicative` is for `List`.