### PR TITLE
Extend capabilities to summon instances

### DIFF
--- a/modules/deriving/src/main/scala/shapeless3/deriving/internals/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/internals/kinds.scala
@@ -1,0 +1,30 @@
+package shapeless3.deriving.internals
+
+import scala.compiletime.*
+import scala.util.NotGiven
+
+object Kinds:
+  transparent inline def summonFirst[T]: Any =
+    inline erasedValue[T] match
+      case _: (a *: b) => summonFrom {
+        case instance: a => instance
+        case _ => summonFirst[b]
+      }
+
+  transparent inline def summonOnly[T]: Any =
+    inline erasedValue[T] match
+      case _: (a *: b) =>
+        summonFrom {
+          case instance: a =>
+            summonNone[b]
+            instance
+          case _ =>
+            summonOnly[b]
+        }
+
+  transparent inline def summonNone[T]: Unit =
+    inline erasedValue[T] match
+      case _: EmptyTuple => ()
+      case _: (a *: b) =>
+        summonInline[NotGiven[a]]
+        summonNone[b]

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -96,7 +96,7 @@ object K0 {
     inline erasedValue[T] match
       case _: (a *: b) =>
         summonFrom {
-          case instance: `a` =>
+          case instance: a =>
             summonNone0[b]
             instance
           case _ =>
@@ -107,7 +107,7 @@ object K0 {
     inline erasedValue[T] match
       case _: EmptyTuple => ()
       case _: (a *: b) =>
-        summonInline[NotGiven[`a`]]
+        summonInline[NotGiven[a]]
         summonNone0[b]
 
   extension [T](gen: ProductGeneric[T])

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -16,12 +16,13 @@
 
 package shapeless3.deriving
 
+import shapeless3.deriving.internals.*
+
+import scala.Tuple.Union
 import scala.compiletime.*
 import scala.compiletime.ops.int.S
 import scala.deriving.*
-import scala.Tuple.Union
-
-import shapeless3.deriving.internals.*
+import scala.util.NotGiven
 
 object K0 {
   type Kind[C, O] = C {
@@ -66,6 +67,10 @@ object K0 {
       case _ => EmptyTuple
     }
 
+  /**
+   * Summon the first given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` may or may not have an instance of `F`.
+   */
   inline def summonFirst[F[_], T, U]: F[U] =
     summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
 
@@ -75,6 +80,35 @@ object K0 {
         case instance: `a` => instance
         case _ => summonFirst0[b]
       }
+
+  /**
+   * Summon the only given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` are guaranteed to not have an instance of `F`.
+   */
+  inline def summonOnly[F[_], T, U]: F[U] =
+    summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+
+  /** Ensure that no element of the tuple `T` has an instance of `F`. */
+  inline def summonNone[F[_], T]: Unit =
+    summonNone0[LiftP[F, T]]
+
+  transparent inline def summonOnly0[T]: Any =
+    inline erasedValue[T] match
+      case _: (a *: b) =>
+        summonFrom {
+          case instance: `a` =>
+            summonNone0[b]
+            instance
+          case _ =>
+            summonOnly0[b]
+        }
+
+  transparent inline def summonNone0[T]: Unit =
+    inline erasedValue[T] match
+      case _: EmptyTuple => ()
+      case _: (a *: b) =>
+        summonInline[NotGiven[`a`]]
+        summonNone0[b]
 
   extension [T](gen: ProductGeneric[T])
     inline def toRepr(o: T): gen.MirroredElemTypes = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes]
@@ -185,11 +219,26 @@ object K1 {
       case _ => EmptyTuple
     }
 
+  /**
+   * Summon the first given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` may or may not have an instance of `F`.
+   */
   inline def summonFirst[F[_[_]], T[_], U[_]]: F[U] =
     K0.summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
 
   transparent inline def summonFirst0[T]: Any =
     K0.summonFirst0[T]
+
+  /**
+   * Summon the only given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` are guaranteed to not have an instance of `F`.
+   */
+  inline def summonOnly[F[_[_]], T[_], U[_]]: F[U] =
+    K0.summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+
+  /** Ensure that no element of the tuple `T` has an instance of `F`. */
+  inline def summonNone[F[_[_]], T[_]]: Unit =
+    K0.summonNone0[LiftP[F, T]]
 
   extension [T[_], A] (gen: ProductGeneric[T])
     inline def toRepr(o: T[A]): gen.MirroredElemTypes[A] = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes[A]]
@@ -296,11 +345,26 @@ object K11 {
       case _ => EmptyTuple
     }
 
+  /**
+   * Summon the first given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` may or may not have an instance of `F`.
+   */
   inline def summonFirst[F[_[_[_]]], T[_[_]], U[_[_]]]: F[U] =
     K0.summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
 
   transparent inline def summonFirst0[T]: Any =
     K0.summonFirst0[T]
+
+  /**
+   * Summon the only given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` are guaranteed to not have an instance of `F`.
+   */
+  inline def summonOnly[F[_[_[_]]], T[_[_]], U[_[_]]]: F[U] =
+    K0.summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+
+  /** Ensure that no element of the tuple `T` has an instance of `F`. */
+  inline def summonNone[F[_[_[_]]], T[_[_]]]: Unit =
+    K0.summonNone0[LiftP[F, T]]
 
   extension [T[_[_]], A[_]](gen: ProductGeneric[T])
     inline def toRepr(o: T[A]): gen.MirroredElemTypes[A] = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes[A]]
@@ -408,11 +472,26 @@ object K2 {
       case _ => EmptyTuple
     }
 
+  /**
+   * Summon the first given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` may or may not have an instance of `F`.
+   */
   inline def summonFirst[F[_[_, _]], T[_, _], U[_, _]]: F[U] =
     K0.summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
 
   transparent inline def summonFirst0[T]: Any =
     K0.summonFirst0[T]
+
+  /**
+   * Summon the only given instance `F[U]` from the tuple `T`.
+   * Remaining elements of `T` are guaranteed to not have an instance of `F`.
+   */
+  inline def summonOnly[F[_[_, _]], T[_, _], U[_, _]]: F[U] =
+    K0.summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+
+  /** Ensure that no element of the tuple `T` has an instance of `F`. */
+  inline def summonNone[F[_[_, _]], T[_, _], U[_, _]]: Unit =
+    K0.summonNone0[LiftP[F, T]]
 
   extension [T[_, _], A, B](gen: ProductGeneric[T]) inline def toRepr(o: T[A, B]): gen.MirroredElemTypes[A, B] = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes[A, B]]
   extension [T[_, _], A, B](gen: ProductGeneric[T]) inline def fromRepr(r: gen.MirroredElemTypes[A, B]): T[A, B] = gen.fromProduct(r.asInstanceOf).asInstanceOf[T[A, B]]

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -72,43 +72,22 @@ object K0 {
    * Remaining elements of `T` may or may not have an instance of `F`.
    */
   inline def summonFirst[F[_], T, U]: F[U] =
-    summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonFirst[LiftP[F, T]].asInstanceOf[F[U]]
 
+  @deprecated("Use summonFirst instead", "3.2.0")
   transparent inline def summonFirst0[T]: Any =
-    inline erasedValue[T] match
-      case _: (a *: b) => summonFrom {
-        case instance: `a` => instance
-        case _ => summonFirst0[b]
-      }
+    Kinds.summonFirst[T]
 
   /**
    * Summon the only given instance `F[U]` from the tuple `T`.
    * Remaining elements of `T` are guaranteed to not have an instance of `F`.
    */
   inline def summonOnly[F[_], T, U]: F[U] =
-    summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonOnly[LiftP[F, T]].asInstanceOf[F[U]]
 
   /** Ensure that no element of the tuple `T` has an instance of `F`. */
   inline def summonNone[F[_], T]: Unit =
-    summonNone0[LiftP[F, T]]
-
-  transparent inline def summonOnly0[T]: Any =
-    inline erasedValue[T] match
-      case _: (a *: b) =>
-        summonFrom {
-          case instance: a =>
-            summonNone0[b]
-            instance
-          case _ =>
-            summonOnly0[b]
-        }
-
-  transparent inline def summonNone0[T]: Unit =
-    inline erasedValue[T] match
-      case _: EmptyTuple => ()
-      case _: (a *: b) =>
-        summonInline[NotGiven[a]]
-        summonNone0[b]
+    Kinds.summonNone[LiftP[F, T]]
 
   extension [T](gen: ProductGeneric[T])
     inline def toRepr(o: T): gen.MirroredElemTypes = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes]
@@ -224,21 +203,22 @@ object K1 {
    * Remaining elements of `T` may or may not have an instance of `F`.
    */
   inline def summonFirst[F[_[_]], T[_], U[_]]: F[U] =
-    K0.summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonFirst[LiftP[F, T]].asInstanceOf[F[U]]
 
+  @deprecated("Use summonFirst instead", "3.2.0")
   transparent inline def summonFirst0[T]: Any =
-    K0.summonFirst0[T]
+    Kinds.summonFirst[T]
 
   /**
    * Summon the only given instance `F[U]` from the tuple `T`.
    * Remaining elements of `T` are guaranteed to not have an instance of `F`.
    */
   inline def summonOnly[F[_[_]], T[_], U[_]]: F[U] =
-    K0.summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonOnly[LiftP[F, T]].asInstanceOf[F[U]]
 
   /** Ensure that no element of the tuple `T` has an instance of `F`. */
   inline def summonNone[F[_[_]], T[_]]: Unit =
-    K0.summonNone0[LiftP[F, T]]
+    Kinds.summonNone[LiftP[F, T]]
 
   extension [T[_], A] (gen: ProductGeneric[T])
     inline def toRepr(o: T[A]): gen.MirroredElemTypes[A] = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes[A]]
@@ -350,21 +330,22 @@ object K11 {
    * Remaining elements of `T` may or may not have an instance of `F`.
    */
   inline def summonFirst[F[_[_[_]]], T[_[_]], U[_[_]]]: F[U] =
-    K0.summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonFirst[LiftP[F, T]].asInstanceOf[F[U]]
 
+  @deprecated("Use summonFirst instead", "3.2.0")
   transparent inline def summonFirst0[T]: Any =
-    K0.summonFirst0[T]
+    Kinds.summonFirst[T]
 
   /**
    * Summon the only given instance `F[U]` from the tuple `T`.
    * Remaining elements of `T` are guaranteed to not have an instance of `F`.
    */
   inline def summonOnly[F[_[_[_]]], T[_[_]], U[_[_]]]: F[U] =
-    K0.summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonOnly[LiftP[F, T]].asInstanceOf[F[U]]
 
   /** Ensure that no element of the tuple `T` has an instance of `F`. */
   inline def summonNone[F[_[_[_]]], T[_[_]]]: Unit =
-    K0.summonNone0[LiftP[F, T]]
+    Kinds.summonNone[LiftP[F, T]]
 
   extension [T[_[_]], A[_]](gen: ProductGeneric[T])
     inline def toRepr(o: T[A]): gen.MirroredElemTypes[A] = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes[A]]
@@ -477,21 +458,22 @@ object K2 {
    * Remaining elements of `T` may or may not have an instance of `F`.
    */
   inline def summonFirst[F[_[_, _]], T[_, _], U[_, _]]: F[U] =
-    K0.summonFirst0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonFirst[LiftP[F, T]].asInstanceOf[F[U]]
 
+  @deprecated("Use summonFirst instead", "3.2.0")
   transparent inline def summonFirst0[T]: Any =
-    K0.summonFirst0[T]
+    Kinds.summonFirst[T]
 
   /**
    * Summon the only given instance `F[U]` from the tuple `T`.
    * Remaining elements of `T` are guaranteed to not have an instance of `F`.
    */
   inline def summonOnly[F[_[_, _]], T[_, _], U[_, _]]: F[U] =
-    K0.summonOnly0[LiftP[F, T]].asInstanceOf[F[U]]
+    Kinds.summonOnly[LiftP[F, T]].asInstanceOf[F[U]]
 
   /** Ensure that no element of the tuple `T` has an instance of `F`. */
   inline def summonNone[F[_[_, _]], T[_, _], U[_, _]]: Unit =
-    K0.summonNone0[LiftP[F, T]]
+    Kinds.summonNone[LiftP[F, T]]
 
   extension [T[_, _], A, B](gen: ProductGeneric[T]) inline def toRepr(o: T[A, B]): gen.MirroredElemTypes[A, B] = Tuple.fromProduct(o.asInstanceOf).asInstanceOf[gen.MirroredElemTypes[A, B]]
   extension [T[_, _], A, B](gen: ProductGeneric[T]) inline def fromRepr(r: gen.MirroredElemTypes[A, B]): T[A, B] = gen.fromProduct(r.asInstanceOf).asInstanceOf[T[A, B]]

--- a/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
@@ -25,7 +25,7 @@ object adts {
 
   case class Recursive(h: Int, t: Option[Recursive]) derives Monoid
 
-  sealed trait OptionInt derives Eq, Empty, Show, Read, Ord
+  sealed trait OptionInt derives Eq, Show, Read, Ord
   case object NoneInt extends OptionInt
   case class SomeInt(value: Int) extends OptionInt
 
@@ -73,4 +73,14 @@ object adts {
   case class BI(b: Boolean, i: Int)
   
   case class Phantom[A]()
+
+  enum LongList derives Empty:
+    case Nil()
+    case Cons(value: Long, tail: LongList)
+
+  enum Zipper[A] derives NonEmpty:
+    case Rep(n: Int, value: Some[A])
+    case Top(head: A, tail: Zipper[A])
+    case Bot(init: Zipper[A], last: A)
+    case Focus(left: List[A], focus: ::[A], right: List[A])
 }


### PR DESCRIPTION
 * `summonOnly` - summon exactly one instance or fail
 * `summonNone` - ensure there are no instances available

I'm not sure of the names. If that seems useful, I will add some tests.