### PR TITLE
Migrate to sbt-typelevel-ci-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,6 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
 
-      - name: Check headers and formatting
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
-
       - name: fastOptJS
         if: matrix.project == 'rootJS'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/fastOptJS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
   build:
     name: Build and Test
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         scala: [3.1.0]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
     tags: [v*]
 
 env:
+  PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  PGP_SECRET: ${{ secrets.PGP_SECRET }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -26,7 +30,7 @@ jobs:
         os: [ubuntu-latest]
         scala: [3.1.0]
         java: [temurin@8]
-        platform: [jvm, js, native]
+        project: [rootJS, rootJVM, rootNative]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -54,24 +58,44 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
 
-      - name: Validate JVM
-        if: matrix.platform == 'jvm'
-        run: sbt ++${{ matrix.scala }} validateJVM
+      - name: Check headers and formatting
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
-      - name: Validate JS
-        if: matrix.platform == 'js'
-        run: sbt ++${{ matrix.scala }} validateJS
+      - name: fastOptJS
+        if: matrix.project == 'rootJS'
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/fastOptJS
 
-      - name: Validate Native
-        if: matrix.platform == 'native'
-        run: sbt ++${{ matrix.scala }} validateNative
+      - name: nativeLink
+        if: matrix.project == 'rootNative'
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/nativeLink
+
+      - name: Test
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
+
+      - name: Check binary compatibility
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' mimaReportBinaryIssues
+
+      - name: Generate API documentation
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' doc
+
+      - name: Make target directories
+        run: mkdir -p modules/deriving/.js/target modules/test/.jvm/target modules/test/.native/target target .js/target modules/typeable/.js/target modules/deriving/.jvm/target modules/typeable/.native/target .jvm/target .native/target local/.native/target local/.js/target modules/test/.js/target modules/typeable/.jvm/target local/.jvm/target modules/deriving/.native/target project/target
+
+      - name: Compress target directories
+        run: tar cf targets.tar modules/deriving/.js/target modules/test/.jvm/target modules/test/.native/target target .js/target modules/typeable/.js/target modules/deriving/.jvm/target modules/typeable/.native/target .jvm/target .native/target local/.native/target local/.js/target modules/test/.js/target modules/typeable/.jvm/target local/.jvm/target modules/deriving/.native/target project/target
+
+      - name: Upload target directories
+        uses: actions/upload-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}
+          path: targets.tar
 
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -103,11 +127,26 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - uses: olafurpg/setup-gpg@v3
+      - name: Download target directories (3.1.0)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.1.0-${{ matrix.java }}
 
-      - env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: sbt ++${{ matrix.scala }} ci-release
+      - name: Inflate target directories (3.1.0)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Import signing key
+        if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
+        run: echo $PGP_SECRET | base64 -d | gpg --import
+
+      - name: Import signing key and strip passphrase
+        if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE != ''
+        run: |
+          echo "$PGP_SECRET" | base64 -d > /tmp/signing-key.gpg
+          echo "$PGP_PASSPHRASE" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg
+          (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
+
+      - name: Publish
+        run: sbt '++${{ matrix.scala }}' tlRelease

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,14 @@ import com.typesafe.tools.mima.core.{ProblemFilters, ReversedMissingMethodProble
 
 val scala3Version = "3.1.0"
 
+ThisBuild / organization := "org.typelevel"
 ThisBuild / tlBaseVersion := "3.0"
+ThisBuild / scalaVersion := scala3Version
 ThisBuild / crossScalaVersions := Seq(scala3Version)
 ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 // GHA configuration
+ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
 
 val nativeSettings = Def.settings(
@@ -127,8 +130,8 @@ lazy val local = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 // Settings
 
 lazy val commonSettings = Seq(
-  tlFatalWarnings := true,
   scalacOptions ++= Seq(
+    "-Xfatal-warnings",
     "-Yexplicit-nulls"
   ),
   Compile / doc / sources := Nil,
@@ -136,6 +139,7 @@ lazy val commonSettings = Seq(
   libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
 )
 
+ThisBuild / licenses := Seq("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / developers := List(
   Developer("milessabin", "Miles Sabin", "miles@milessabin.com", url("http://milessabin.com/blog")),
   Developer("joroKr21", "Georgi Krastev", "joro.kr.21@gmail.com", url("https://twitter.com/Joro_Kr")),

--- a/build.sbt
+++ b/build.sbt
@@ -3,14 +3,13 @@ import com.typesafe.tools.mima.core.{ProblemFilters, ReversedMissingMethodProble
 val scala3Version = "3.1.0"
 
 ThisBuild / organization := "org.typelevel"
-ThisBuild / tlBaseVersion := "3.0"
+ThisBuild / tlBaseVersion := "3.1"
 ThisBuild / scalaVersion := scala3Version
 ThisBuild / crossScalaVersions := Seq(scala3Version)
 ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 // GHA configuration
 ThisBuild / tlCiReleaseBranches := Seq("main")
-ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
 
 val jsSettings = Def.settings(
   tlVersionIntroduced := Map("3" -> "3.0.1")

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val deriving = crossProject(JSPlatform, JVMPlatform, NativePlatform)
        ProblemFilters.exclude[ReversedMissingMethodProblem]("shapeless3.deriving.internals.ErasedProductInstances.erasedMapK")
      )
    )
-  .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
+  .jsEnablePlugins(ScalaJSJUnitPlugin)
 
 lazy val derivingJVM = deriving.jvm
 lazy val derivingJS = deriving.js
@@ -97,7 +97,7 @@ lazy val test = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(commonSettings)
   .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
-  .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
+  .jsEnablePlugins(ScalaJSJUnitPlugin)
 
 lazy val testJVM = test.jvm
 lazy val testJS = test.js
@@ -114,7 +114,7 @@ lazy val typeable = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(mimaPreviousArtifacts := Set.empty) // Not yet
   .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
-  .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
+  .jsEnablePlugins(ScalaJSJUnitPlugin)
 
 lazy val typeableJVM = typeable.jvm
 lazy val typeableJS = typeable.js
@@ -133,7 +133,7 @@ lazy val local = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .settings(commonSettings)
   .enablePlugins(NoPublishPlugin)
-  .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
+  .jsEnablePlugins(ScalaJSJUnitPlugin)
 
 // Settings
 

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,6 @@ lazy val typeable = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .settings(commonSettings)
   .settings(mimaPreviousArtifacts := Set.empty) // Not yet
-  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
   .jsEnablePlugins(ScalaJSJUnitPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,15 @@ ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
 
+val jsSettings = Def.settings(
+  tlVersionIntroduced := Map("3" -> "3.0.1")
+)
+
 val nativeSettings = Def.settings(
   libraryDependencies += "org.scala-native" %%% "junit-runtime" % nativeVersion % Test,
   addCompilerPlugin("org.scala-native" % "junit-plugin" % nativeVersion cross CrossVersion.full),
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v"),
+  mimaPreviousArtifacts := Set.empty,
 )
 
 // Aliases
@@ -53,6 +58,7 @@ lazy val deriving = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .platformsSettings(JVMPlatform, JSPlatform)(
     libraryDependencies += "org.typelevel" %%% "cats-core" % "2.7.0" % "test",
   )
+  .jsSettings(jsSettings)
   .nativeSettings(
     nativeSettings,
     Test / sources := {
@@ -89,6 +95,7 @@ lazy val test = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     moduleName := "shapeless3-test"
   )
   .settings(commonSettings)
+  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
 
@@ -105,6 +112,7 @@ lazy val typeable = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .settings(commonSettings)
   .settings(mimaPreviousArtifacts := Set.empty) // Not yet
+  .jsSettings(jsSettings)
   .nativeSettings(nativeSettings)
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,4 @@
-addSbtPlugin("com.github.sbt"     % "sbt-ci-release"           % "1.5.10")
-addSbtPlugin("com.codecommit"     % "sbt-github-actions"       % "0.14.2")
-addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"          % "1.0.1")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.8.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"         % "0.4.3-RC2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.0")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "0.4.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.8.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"         % "0.4.3-RC2")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")


### PR DESCRIPTION
I reached for sbt-typelevel-ci-release instead of sbt-typelevel, since the latter includes scalac settings, formatting, headers, etc. which you are not using/don't want here.