### PR TITLE
Bump base version to 3.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.tools.mima.core.{ProblemFilters, ReversedMissingMethodProble
 val scala3Version = "3.3.1"
 
 ThisBuild / organization := "org.typelevel"
-ThisBuild / tlBaseVersion := "3.3"
+ThisBuild / tlBaseVersion := "3.4"
 ThisBuild / scalaVersion := scala3Version
 ThisBuild / crossScalaVersions := Seq(scala3Version)
 ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)


### PR DESCRIPTION
Best practice is to bump the base version in the PR that makes the changes that require the bump in the next release :)

Unfortunately we cannot enforce this automatically since we are lacking a good way to check forward-binary-compatibility.