### PR TITLE
Use simple typeable for simple case classes

### DIFF
--- a/modules/typeable/src/main/scala/shapeless3/typeable/typeable.scala
+++ b/modules/typeable/src/main/scala/shapeless3/typeable/typeable.scala
@@ -383,10 +383,10 @@ object TypeableMacros:
         val owner = normalizeModuleClass(sym.owner)
 
         qual match
-          case Some(_) if sym.flags.is(Flags.Case) => mkCaseClassTypeable
           case None => mkNamedSimpleTypeable
           case Some(tp: TypeRef) if normalizeModuleClass(tp.typeSymbol) == owner => mkNamedSimpleTypeable
           case Some(tp: TermRef) if normalizeModuleClass(tp.termSymbol) == owner => mkNamedSimpleTypeable
+          case Some(_) if sym.flags.is(Flags.Case) => mkCaseClassTypeable
           case Some(_) if sym.flags.is(Flags.Sealed) => mkSumTypeable
           case _ => report.errorAndAbort(s"No Typeable for type ${target.show} with a dependent prefix")
 

--- a/modules/typeable/src/test/scala/shapeless3/typeable/typeable.scala
+++ b/modules/typeable/src/test/scala/shapeless3/typeable/typeable.scala
@@ -609,5 +609,18 @@ class TypeableTests:
     assertEquals(ti.describe, "Tree[Int]")
     assertEquals(ti.toString, "Typeable[Tree[Int]]")
 
+  @Test
+  def testEnumeration(): Unit =
+    val tc = Typeable[CaseClassWithEnumeration]
+    val cc = CaseClassWithEnumeration()
+    assert(tc.castable(cc))
+    assert(tc.cast(cc).contains(cc))
+
 object TypeableTests:
   final case class Tree[+A](value: A, children: Vector[Tree[A]])
+
+  object E extends scala.Enumeration:
+    val A = Value("a")
+    val B = Value("b")
+
+  case class CaseClassWithEnumeration(name: String = "", e: E.Value = E.A)


### PR DESCRIPTION
I ran into this migrating some code from Scala 2 to 3.
> Missing Typeable for field of case class shapeless3.typeable.TypeableTests.CaseClassWithEnumeration [614:48]
