### PR TITLE
Fix compilation under Scala 3.6 new givens prioritization scheme

### DIFF
--- a/modules/deriving/src/test/scala/shapeless3/deriving/instances.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/instances.scala
@@ -63,7 +63,7 @@ class InstancesTests:
 
   @Test
   def mapKforSingle: Unit =
-    val inst = summon[K0.Instances[TypeClass, Single[Int]]]
+    val inst = summon[K0.ProductInstances[TypeClass, Single[Int]]]
     val otherInst = inst.mapK([t] => (tc: TypeClass[t]) => tc.another)
     val s = Single(42)
 


### PR DESCRIPTION
Applies a patch required after merge of https://github.com/scala/scala3/pull/19300 to one of the tests to make it compile under Scala 3.6 in the Scala 3 Open Community Build. This change is a [cherry-pick from a Scala 3 Small / Managed Communty Build](https://github.com/dotty-staging/shapeless-3/compare/d27c5ba1ae5111b85df2cfb65a26b9246c52570c...90f0c977b536c06305496600b8b2014c9e8e3d86#diff-2a7799e67fbe6ee3e30b043705d05fadb511c31b31aca1ef982b131773a37031) run on the fork of this project 