### PR TITLE
Add methods arity and foldLeft0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,10 @@ lazy val deriving = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("shapeless3.deriving.K0.<clinit>"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("shapeless3.deriving.K1.<clinit>"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("shapeless3.deriving.K11.<clinit>"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("shapeless3.deriving.K2.<clinit>")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("shapeless3.deriving.K2.<clinit>"),
+      // Those are sealed traits:
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("shapeless3.deriving.internals.ErasedInstances.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("shapeless3.deriving.internals.ErasedProductInstances.*")
     )
   )
 

--- a/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
@@ -26,6 +26,7 @@ sealed abstract class ErasedInstances[K, FT] extends Serializable:
   def erasedMapK(f: Any => Any): ErasedInstances[K, ?]
   def erasedMap(x: Any)(f: (Any, Any) => Any): Any
   def erasedTraverse[F[_]](x: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(f: (Any, Any) => F[Any]): F[Any]
+  def arity: Int
 
 sealed abstract class ErasedProductInstances[K, FT] extends ErasedInstances[K, FT]:
   def erasedMapK(f: Any => Any): ErasedProductInstances[K, ?]
@@ -35,6 +36,7 @@ sealed abstract class ErasedProductInstances[K, FT] extends ErasedInstances[K, F
   def erasedUnfold(a: Any)(f: (Any, Any) => (Any, Option[Any])): (Any, Option[Any])
   def erasedMap(x0: Any)(f: (Any, Any) => Any): Any
   def erasedMap2(x0: Any, y0: Any)(f: (Any, Any, Any) => Any): Any
+  def erasedFoldLeft0(a: Any)(f: (Any, Any) => CompleteOr[Any]): Any
   def erasedFoldLeft(x0: Any)(a: Any)(f: (Any, Any, Any) => CompleteOr[Any]): Any
   def erasedFoldLeft2(x0: Any, y0: Any)(a: Any)(f: (Any, Any, Any, Any) => CompleteOr[Any]): Any
   def erasedFoldRight(x0: Any)(a: Any)(f: (Any, Any, Any) => CompleteOr[Any]): Any
@@ -75,6 +77,14 @@ DO NOT USE as it will lead to stack overflows when deriving instances for recurs
 
   def erasedTraverse[F[_]](x: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(f: (Any, Any) => F[Any]): F[Any] =
     map(f(i, toElement(x)), fromElement)
+
+  def arity: Int =
+    1
+
+  def erasedFoldLeft0(a: Any)(f: (Any, Any) => CompleteOr[Any]): Any =
+    f(a, i) match
+      case Complete(r) => r
+      case acc => acc
 
   def erasedMap2(x: Any, y: Any)(f: (Any, Any, Any) => Any): Any =
     fromElement(f(i, toElement(x), toElement(y)))
@@ -194,6 +204,24 @@ DO NOT USE as it will lead to stack overflows when deriving instances for recurs
 
   def erasedTraverse[F[_]](x: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(f: (Any, Any) => F[Any]): F[Any] =
     traverseProduct(toProduct(x), f)(pure, map, ap)
+
+  def arity: Int =
+    is.size
+
+  def erasedFoldLeft0(i: Any)(f: (Any, Any) => CompleteOr[Any]): Any =
+    val n = is.length
+    if n == 0 then i
+    else
+      @tailrec
+      def loop(i: Int, acc: Any): Any =
+        if i >= n then acc
+        else
+          f(acc, is(i)) match
+            case Complete(r) => r
+            case acc =>
+              loop(i + 1, acc)
+
+      loop(0, i)
 
   def erasedMap2(x0: Any, y0: Any)(f: (Any, Any, Any) => Any): Any =
     val n = is.length
@@ -330,6 +358,9 @@ final class ErasedCoproductInstances[K, FT](mirror: Mirror.Sum, is0: => Array[An
 
   def erasedTraverse[F[_]](x: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(f: (Any, Any) => F[Any]): F[Any] =
     f(ordinal(x), x)
+
+  def arity: Int =
+    is.size
 
   def erasedFold2(x: Any, y: Any)(a: => Any)(f: (Any, Any, Any) => Any): Any =
     val i = mirror.ordinal(x.asInstanceOf)

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -320,6 +320,8 @@ object K1
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
     inline def foldLeft[A, Acc](x: T[A])(i: Acc)(f: [t[_]] => (Acc, F[t], t[A]) => CompleteOr[Acc]): Acc =
       inst.erasedFoldLeft(x)(i)(f.asInstanceOf).asInstanceOf
+    inline def foldLeft0[Acc](i: Acc)(f: [t[_]] => (Acc, F[t]) => CompleteOr[Acc]): Acc =
+      inst.erasedFoldLeft0(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft2[A, B, Acc](x: T[A], y: T[B])(i: Acc)(
         f: [t[_]] => (Acc, F[t], t[A], t[B]) => CompleteOr[Acc]
     ): Acc =
@@ -392,6 +394,8 @@ object K11
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
     inline def foldLeft[A[_], Acc](x: T[A])(i: Acc)(f: [t[_[_]]] => (Acc, F[t], t[A]) => CompleteOr[Acc]): Acc =
       inst.erasedFoldLeft(x)(i)(f.asInstanceOf).asInstanceOf
+    inline def foldLeft0[Acc](i: Acc)(f: [t[_[_]]] => (Acc, F[t]) => CompleteOr[Acc]): Acc =
+      inst.erasedFoldLeft0(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft2[A[_], B[_], Acc](x: T[A], y: T[B])(i: Acc)(
         f: [t[_[_]]] => (Acc, F[t], t[A], t[B]) => CompleteOr[Acc]
     ): Acc =
@@ -472,6 +476,8 @@ object K2
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
     inline def foldLeft[A, B, Acc](x: T[A, B])(i: Acc)(f: [t[_, _]] => (Acc, F[t], t[A, B]) => CompleteOr[Acc]): Acc =
       inst.erasedFoldLeft(x)(i)(f.asInstanceOf).asInstanceOf
+    inline def foldLeft0[Acc](i: Acc)(f: [t[_, _]] => (Acc, F[t]) => CompleteOr[Acc]): Acc =
+      inst.erasedFoldLeft0(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft2[A, B, C, D, Acc](x: T[A, B], y: T[C, D])(i: Acc)(
         f: [t[_, _]] => (Acc, F[t], t[A, B], t[C, D]) => CompleteOr[Acc]
     ): Acc =

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -245,6 +245,8 @@ object K0 extends Kind[Any, Tuple, Id, Kinds.Head, Kinds.Tail]:
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
     inline def unfold[Acc](i: Acc)(f: [t] => (Acc, F[t]) => (Acc, Option[t])): (Acc, Option[T]) =
       inst.erasedUnfold(i)(f.asInstanceOf).asInstanceOf
+    inline def foldLeft0[Acc](i: Acc)(f: [t] => (Acc, F[t]) => CompleteOr[Acc]): Acc =
+      inst.erasedFoldLeft0(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft[Acc](x: T)(i: Acc)(f: [t] => (Acc, F[t], t) => CompleteOr[Acc]): Acc =
       inst.erasedFoldLeft(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft2[Acc](x: T, y: T)(i: Acc)(f: [t] => (Acc, F[t], t, t) => CompleteOr[Acc]): Acc =

--- a/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
@@ -21,21 +21,21 @@ import cats.data.{EitherK, Tuple2K}
 // ADTs
 
 object adts:
-  case class ISB(i: Int, s: String, b: Boolean) derives Monoid, Eq, Empty, Show, Read
+  case class ISB(i: Int, s: String, b: Boolean) derives Monoid, Eq, Empty, Show, ShowType, Read
 
-  case class Box[A](x: A) derives Monoid, Eq, Show, Read, Functor, Return, Ord, Traverse, Foldable
+  case class Box[A](x: A) derives Monoid, Eq, Show, ShowType, Read, Functor, Return, Ord, Traverse, Foldable
 
   case class Recursive(h: Int, t: Option[Recursive]) derives Monoid
 
-  sealed trait OptionInt derives Eq, Show, Read, Ord
+  sealed trait OptionInt derives Eq, Show, ShowType, Read, Ord
   case object NoneInt extends OptionInt
   case class SomeInt(value: Int) extends OptionInt
 
-  sealed trait Opt[+A] derives Eq, Show, Read, Functor, EmptyK, Return, Ord, Traverse, Foldable
+  sealed trait Opt[+A] derives Eq, Show, ShowType, Read, Functor, EmptyK, Return, Ord, Traverse, Foldable
   case object Nn extends Opt[Nothing]
   case class Sm[+A](value: A) extends Opt[A]
 
-  enum OptE[+T] derives Eq, Show, Read, Functor, Ord, Traverse, Foldable:
+  enum OptE[+T] derives Eq, Show, ShowType, Read, Functor, Ord, Traverse, Foldable:
     case NnE
     case SmE(value: T)
 

--- a/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
@@ -350,6 +350,29 @@ class DerivationTests:
     assert(v6.show(NnE) == "NnE")
 
   @Test
+  def showType(): Unit =
+    val v0 = ShowType[ISB]
+    assert(v0.show == """ISB(i: Int, s: String, b: Boolean)""")
+
+    val v1 = ShowType[OptionInt]
+    assert(v1.show == "NoneInt | SomeInt(value: Int)")
+
+    val v2 = ShowType[Box[Int]]
+    assert(v2.show == "Box(x: Int)")
+
+    val v3 = ShowType[Opt[Int]]
+    assert(v3.show == "Nn | Sm(value: Int)")
+
+    val v4 = ShowType[OptE[Int]]
+    assert(v4.show == "NnE | SmE(value: Int)")
+
+    val v5 = ShowType[Order[Id]]
+    assert(v5.show == "Order(item: String, quantity: Int)")
+
+    val v6 = ShowType[Order[Option]]
+    assert(v6.show == "Order(item: None | Some(value: String), quantity: None | Some(value: Int))")
+
+  @Test
   def read(): Unit =
     val v0 = Read[ISB]
     assert(v0.read("""ISB(i: 23, s: "foo", b: true)""").contains((ISB(23, "foo", true), "")))


### PR DESCRIPTION
I am not sure foldLeft0 is the perfect or desired interface. But I am opening this PR to show that (at least to my understanding) a TypeClass like ShowType can not be implemented in the current interface.

Of course one can argue that the traversal in ShowType should be done at compile time since it does not depend on any runtime values. But I have a use case where I want to have a type class that need to traverse the elements in multiple ways and being able to implement all of them using the shapeless 3 API would be useful.