### PR TITLE
Upstream Derived from kittens

### DIFF
--- a/modules/deriving/src/main/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/deriving.scala
@@ -16,6 +16,8 @@
 
 package shapeless3.deriving
 
+import shapeless3.deriving.internals.ErasedInstances
+
 import scala.annotation.implicitNotFound
 import scala.collection.immutable.ArraySeq
 import scala.compiletime.*
@@ -91,7 +93,7 @@ object Continue:
 opaque type Derived[A] = A
 object Derived:
   def apply[A](instance: A): Derived[A] = instance
-  given [A]: Conversion[A, Derived[A]] = identity
+  given conv[A]: Conversion[A, Derived[A]] = identity
   extension [A](derived: Derived[A]) def instance: A = derived
   extension [A](derived: OrElse[A, Derived[A]]) def unify: A = OrElse.unify(derived)
 
@@ -99,10 +101,11 @@ object Derived:
 opaque type OrElse[A, B] = A | B
 object OrElse extends OrInstances:
   def apply[A, B](instance: A | B): OrElse[A, B] = instance
-  given [A, B]: Conversion[OrElse[A, B], A | B] = identity
+  given conv[A, B]: Conversion[OrElse[A, B], A | B] = identity
   extension [A, B](orElse: OrElse[A, B]) def unify: A | B = orElse
+  extension [I[k, t] <: ErasedInstances[k, t], K, T](inst: I[K, OrElse[T, Derived[T]]]) def unify: I[K, T] = inst
 
 sealed abstract class OrInstances:
-  inline given [A, B]: OrElse[A, B] = summonFrom:
+  inline given orElse[A, B]: OrElse[A, B] = summonFrom:
     case instance: A => OrElse(instance)
     case instance: B => OrElse(instance)

--- a/modules/deriving/src/main/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/deriving.scala
@@ -16,13 +16,19 @@
 
 package shapeless3.deriving
 
+import scala.annotation.implicitNotFound
 import scala.collection.immutable.ArraySeq
 import scala.compiletime.*
 import scala.deriving.*
 import scala.reflect.ClassTag
 
+/** The identity type lambda. */
 type Id[t] = t
-type Const[c] = [t] =>> c
+
+/** A type lambda that returns a constant type. */
+type Const[c] = [_] =>> c
+
+/** Corresponds to `FunctionK` in Cats. */
 infix type ~>[A[_], B[_]] = [t] => A[t] => B[t]
 
 /** Corresponds to `Applicative.pure` in Cats. */
@@ -37,18 +43,22 @@ type Ap[F[_]] = [a, b] => (F[a => b], F[a]) => F[b]
 /** Corresponds to `FlatMap.tailRecM` in Cats. */
 type TailRecM[F[_]] = [a, b] => (a, a => F[Either[a, b]]) => F[b]
 
+/** Summon all elements from the tuple `T` as an array. */
 inline def summonAsArray[T <: Tuple]: Array[Any] =
   summonAsArray0[T](0, new Array[Any](constValue[Tuple.Size[T]]))
 
+/** Summon all elements from the tuple `T` into the provided array from index `i`. */
 inline def summonAsArray0[T](i: Int, arr: Array[Any]): Array[Any] = inline erasedValue[T] match
   case _: EmptyTuple => arr
   case _: (a *: b) =>
     arr(i) = summonInline[a]
     summonAsArray0[b](i + 1, arr)
 
+/** Summon all elements from the tuple `T` with a known upper bound as an array. */
 inline def summonValuesAsArray[T <: Tuple, E: ClassTag]: Array[E] =
   summonValuesAsArray0[T, E](0, new Array[E](constValue[Tuple.Size[T]]))
 
+/** Summon all elements from the tuple `T` with a known upper bound into the provided array from index `i`. */
 inline def summonValuesAsArray0[T, E](i: Int, arr: Array[E]): Array[E] = inline erasedValue[T] match
   case _: EmptyTuple => arr
   case _: (a *: b) =>
@@ -57,20 +67,42 @@ inline def summonValuesAsArray0[T, E](i: Int, arr: Array[E]): Array[E] = inline 
 
 case class Labelling[T](label: String, elemLabels: IndexedSeq[String])
 object Labelling:
-  inline given apply[T0](using mirror: Mirror { type MirroredType = T0 }): Labelling[T0] =
-    Labelling[T0](
+  inline given apply[T](using mirror: Mirror { type MirroredType = T }): Labelling[T] =
+    Labelling[T](
       constValue[mirror.MirroredLabel & String],
       ArraySeq.unsafeWrapArray(summonValuesAsArray[mirror.MirroredElemLabels, String])
     )
 
+/** A type used to decide whether to continue folding over a product or short-circuit. */
 type CompleteOr[T] = T | Complete[T]
 
+/** Part of [[CompleteOr]] used to signal that folding should short-circuit. */
 case class Complete[T](t: T)
-
 object Complete:
   inline def apply[T](c: Boolean)(t: T)(f: T): CompleteOr[T] =
-    if c then Complete(t)
-    else f
+    if c then Complete(t) else f
 
+/** Part of [[CompleteOr]] used to signal that folding should continue. */
 object Continue:
   inline def apply[T](t: T): CompleteOr[T] = t
+
+/** An opaque type wrapper useful for deriving third-party type classes. */
+@implicitNotFound("Could not derive an instance of ${A}")
+opaque type Derived[A] = A
+object Derived:
+  def apply[A](instance: A): Derived[A] = instance
+  given [A]: Conversion[A, Derived[A]] = identity
+  extension [A](derived: Derived[A]) def instance: A = derived
+  extension [A](derived: OrElse[A, Derived[A]]) def unify: A = OrElse.unify(derived)
+
+/** A type-level `orElse` - tries to summon `A` first and if not found, then `B`. */
+opaque type OrElse[A, B] = A | B
+object OrElse extends OrInstances:
+  def apply[A, B](instance: A | B): OrElse[A, B] = instance
+  given [A, B]: Conversion[OrElse[A, B], A | B] = identity
+  extension [A, B](orElse: OrElse[A, B]) def unify: A | B = orElse
+
+sealed abstract class OrInstances:
+  inline given [A, B]: OrElse[A, B] = summonFrom:
+    case instance: A => OrElse(instance)
+    case instance: B => OrElse(instance)

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -139,11 +139,6 @@ trait Kind[Up <: AnyKind, Tup <: AnyKind, Mono[_ <: Up], Head[_ <: Tup] <: Up, T
   inline given mkCoproductInstances[F[_ <: Up], T <: Up](using gen: Mirror.Sum of T): CoproductInstances[F, T] =
     ErasedCoproductInstances[self.type, F[T], LiftP[F, gen.MirroredElemTypes]](gen)
 
-  /** Given instances of [[Derived.OrElse]], implicitly unifies them to the underlying type class. */
-  given unifiedInstances[I[k, t] <: ErasedInstances[k, t], T](using
-      inst: I[self.type, OrElse[T, Derived[T]]]
-  ): I[self.type, T] = inst.asInstanceOf
-
   /**
    * Summon the first given instance of `F` from the tuple type `T`. Remaining elements of `T` may or may not have an
    * instance of `F`.

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -139,6 +139,11 @@ trait Kind[Up <: AnyKind, Tup <: AnyKind, Mono[_ <: Up], Head[_ <: Tup] <: Up, T
   inline given mkCoproductInstances[F[_ <: Up], T <: Up](using gen: Mirror.Sum of T): CoproductInstances[F, T] =
     ErasedCoproductInstances[self.type, F[T], LiftP[F, gen.MirroredElemTypes]](gen)
 
+  /** Given instances of [[Derived.OrElse]], implicitly unifies them to the underlying type class. */
+  given unifiedInstances[I[k, t] <: ErasedInstances[k, t], T](using
+      inst: I[self.type, OrElse[T, Derived[T]]]
+  ): I[self.type, T] = inst.asInstanceOf
+
   /**
    * Summon the first given instance of `F` from the tuple type `T`. Remaining elements of `T` may or may not have an
    * instance of `F`.
@@ -200,6 +205,9 @@ trait Kind[Up <: AnyKind, Tup <: AnyKind, Mono[_ <: Up], Head[_ <: Tup] <: Up, T
     inline def widen[G[t <: Up] >: F[t]]: CoproductInstances[G, T] = inst.asInstanceOf
 
 object K0 extends Kind[Any, Tuple, Id, Kinds.Head, Kinds.Tail]:
+  infix type |:[F[_], G[_]] =
+    [x] =>> OrElse[F[x], G[F[x]]]
+
   /** Returns the index of element type `E` in the tuple type `T` as a literal type, `-1` if `E` is not in `T`. */
   type IndexOf[E, T] = IndexOf0[E, T, 0]
   type IndexOf0[E, T, I <: Int] <: Int = T match
@@ -280,6 +288,9 @@ object K1
       [t[_]] =>> [a] =>> Kinds.Tail[t[a]]
     ]:
 
+  infix type |:[F[_[_]], G[_]] =
+    [x[_]] =>> OrElse[F[x], G[F[x]]]
+
   @deprecated("Use summonFirst instead", "3.2.0")
   transparent inline def summonFirst0[T <: Tuple]: Any = Kinds.summonFirst[T]
 
@@ -354,6 +365,8 @@ object K11
 
   type Id[t] = [f[_]] =>> f[t]
   type Const[c] = [f[_]] =>> c
+  infix type |:[F[_[_[_]]], G[_]] =
+    [x[_[_]]] =>> OrElse[F[x], G[F[x]]]
 
   extension [T[_[_]], A[_]](gen: ProductGeneric[T])
     /** $productToRepr */
@@ -431,6 +444,8 @@ object K2
   type Id1[t, u] = t
   type Id2[t, u] = u
   type Const[c] = [t, u] =>> c
+  infix type |:[F[_[_, _]], G[_]] =
+    [x[_, _]] =>> OrElse[F[x], G[F[x]]]
 
   @deprecated("Use summonFirst instead", "3.2.0")
   transparent inline def summonFirst0[T <: Tuple]: Any = Kinds.summonFirst[T]

--- a/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
@@ -490,3 +490,25 @@ class DerivationTests:
     bifunctor[ListF]
     functorK[Order]
   end userDefinedMirrors
+
+  @Test
+  def orElsePrimary(): Unit =
+    given Int = 42
+    given String = "Shapeless"
+    val result = summon[OrElse[Int, String]].unify
+    assertEquals(result, 42)
+
+  @Test
+  def orElseSecondary(): Unit =
+    given String = "Shapeless"
+    val result = summon[OrElse[Int, String]].unify
+    assertEquals(result, "Shapeless")
+
+  @Test
+  def unifyDerived(): Unit =
+    import K0.*
+    given Derived[Show[Long]] = Derived(_.toString)
+    val show = summon[(Show |: Derived)[Long]].unify
+    val inst = ProductInstances[Show |: Derived, (String, Long)].unify
+    assertEquals(show.show(42), "42")
+    assertEquals(inst.arity, 2)


### PR DESCRIPTION
It's slightly different, also added type aliases to express:

`[F[_]: Functor |: Derived]` which basically means using `Functor` from implicit scope or else derive one.