### PR TITLE
Add traverse2 to ProductInstances

### DIFF
--- a/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/internals/erased.scala
@@ -38,6 +38,9 @@ sealed abstract class ErasedProductInstances[K, FT] extends ErasedInstances[K, F
   def erasedUnfold(a: Any)(f: (Any, Any) => (Any, Option[Any])): (Any, Option[Any])
   def erasedMap(x0: Any)(f: (Any, Any) => Any): Any
   def erasedMap2(x0: Any, y0: Any)(f: (Any, Any, Any) => Any): Any
+  def erasedTraverse2[F[_]](x0: Any, y0: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(
+      f: (Any, Any, Any) => F[Any]
+  ): F[Any]
   def erasedFoldLeft0(a: Any)(f: (Any, Any) => CompleteOr[Any]): Any
   def erasedFoldLeft(x0: Any)(a: Any)(f: (Any, Any, Any) => CompleteOr[Any]): Any
   def erasedFoldLeft2(x0: Any, y0: Any)(a: Any)(f: (Any, Any, Any, Any) => CompleteOr[Any]): Any
@@ -82,6 +85,11 @@ DO NOT USE as it will lead to stack overflows when deriving instances for recurs
 
   def erasedTraverse[F[_]](x: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(f: (Any, Any) => F[Any]): F[Any] =
     map(f(i, toElement(x)), fromElement)
+
+  def erasedTraverse2[F[_]](x: Any, y: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(
+      f: (Any, Any, Any) => F[Any]
+  ): F[Any] =
+    map(f(i, toElement(x), toElement(y)), fromElement)
 
   def arity: Int =
     1
@@ -239,6 +247,16 @@ DO NOT USE as it will lead to stack overflows when deriving instances for recurs
   def erasedTraverse[F[_]](x: Any)(map: MapF[F])(pure: Pure[F])(ap: Ap[F])(f: (Any, Any) => F[Any]): F[Any] =
     traverseProduct(toProduct(x), f)(pure, map, ap)
 
+  def erasedTraverse2[F[_]](x: Any, y: Any)(
+      map: MapF[F]
+  )(pure: Pure[F])(ap: Ap[F])(f: (Any, Any, Any) => F[Any]): F[Any] =
+    traverseProduct(
+      new ZippedProduct(toProduct(x), toProduct(y)),
+      (inst, pair) =>
+        val (x, y) = pair.asInstanceOf[(Any, Any)]
+        f(inst, x, y)
+    )(pure, map, ap)
+
   def arity: Int =
     is.size
 
@@ -355,6 +373,11 @@ object ErasedProductInstances:
     def productElement(n: Int): Any = elems(n)
     def productArity: Int = elems.length
     override def productIterator: Iterator[Any] = elems.iterator
+
+  final private[internals] class ZippedProduct(p1: Product, p2: Product) extends Product:
+    def canEqual(that: Any): Boolean = false
+    def productElement(n: Int): Any = (p1.productElement(n), p2.productElement(n))
+    def productArity: Int = p1.productArity
 
   private inline def summonOne[T] = inline erasedValue[T] match
     case _: Tuple1[a] => summonInline[a]

--- a/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
+++ b/modules/deriving/src/main/scala/shapeless3/deriving/kinds.scala
@@ -261,6 +261,10 @@ object K0 extends Kind[Any, Tuple, Id, Kinds.Head, Kinds.Tail]:
       inst.erasedConstructM(f.asInstanceOf)(pure, map, tailRecM).asInstanceOf
     inline def map2(x: T, y: T)(f: [t] => (F[t], t, t) => t): T =
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
+    inline def traverse2[G[_]](x: T, y: T)(map: MapF[G])(pure: Pure[G])(ap: Ap[G])(
+        f: [t] => (F[t], t, t) => G[t]
+    ): G[T] =
+      inst.erasedTraverse2(x, y)(map)(pure)(ap)(f.asInstanceOf).asInstanceOf
     inline def unfold[Acc](i: Acc)(f: [t] => (Acc, F[t]) => (Acc, Option[t])): (Acc, Option[T]) =
       inst.erasedUnfold(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft0[Acc](i: Acc)(f: [t] => (Acc, F[t]) => CompleteOr[Acc]): Acc =
@@ -339,6 +343,10 @@ object K1
       inst.erasedConstructM(f.asInstanceOf)(pure, map, tailRecM).asInstanceOf
     inline def map2[A, B, R](x: T[A], y: T[B])(f: [t[_]] => (F[t], t[A], t[B]) => t[R]): T[R] =
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
+    inline def traverse2[A, B, G[_], R](x: T[A], y: T[B])(map: MapF[G])(pure: Pure[G])(ap: Ap[G])(
+        f: [t[_]] => (F[t], t[A], t[B]) => G[t[R]]
+    ): G[T[R]] =
+      inst.erasedTraverse2(x, y)(map)(pure)(ap)(f.asInstanceOf).asInstanceOf
     inline def foldLeft[A, Acc](x: T[A])(i: Acc)(f: [t[_]] => (Acc, F[t], t[A]) => CompleteOr[Acc]): Acc =
       inst.erasedFoldLeft(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft0[Acc](i: Acc)(f: [t[_]] => (Acc, F[t]) => CompleteOr[Acc]): Acc =
@@ -415,6 +423,10 @@ object K11
       inst.erasedConstructM(f.asInstanceOf)(pure, map, tailRecM).asInstanceOf
     inline def map2[A[_], B[_], R[_]](x: T[A], y: T[B])(f: [t[_[_]]] => (F[t], t[A], t[B]) => t[R]): T[R] =
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
+    inline def traverse2[A[_], B[_], G[_], R[_]](x: T[A], y: T[B])(map: MapF[G])(pure: Pure[G])(ap: Ap[G])(
+        f: [t[_[_]]] => (F[t], t[A], t[B]) => G[t[R]]
+    ): G[T[R]] =
+      inst.erasedTraverse2(x, y)(map)(pure)(ap)(f.asInstanceOf).asInstanceOf
     inline def foldLeft[A[_], Acc](x: T[A])(i: Acc)(f: [t[_[_]]] => (Acc, F[t], t[A]) => CompleteOr[Acc]): Acc =
       inst.erasedFoldLeft(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft0[Acc](i: Acc)(f: [t[_[_]]] => (Acc, F[t]) => CompleteOr[Acc]): Acc =
@@ -499,6 +511,10 @@ object K2
         f: [t[_, _]] => (F[t], t[A, B], t[C, D]) => t[R, S]
     ): T[R, S] =
       inst.erasedMap2(x, y)(f.asInstanceOf).asInstanceOf
+    inline def traverse2[A, B, C, D, G[_], R, S](x: T[A, B], y: T[C, D])(map: MapF[G])(pure: Pure[G])(ap: Ap[G])(
+        f: [t[_, _]] => (F[t], t[A, B], t[C, D]) => G[t[R, S]]
+    ): G[T[R, S]] =
+      inst.erasedTraverse2(x, y)(map)(pure)(ap)(f.asInstanceOf).asInstanceOf
     inline def foldLeft[A, B, Acc](x: T[A, B])(i: Acc)(f: [t[_, _]] => (Acc, F[t], t[A, B]) => CompleteOr[Acc]): Acc =
       inst.erasedFoldLeft(x)(i)(f.asInstanceOf).asInstanceOf
     inline def foldLeft0[Acc](i: Acc)(f: [t[_, _]] => (Acc, F[t]) => CompleteOr[Acc]): Acc =

--- a/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/adts.scala
@@ -22,7 +22,9 @@ import scala.deriving.Mirror
 // ADTs
 
 object adts:
-  case class ISB(i: Int, s: String, b: Boolean) derives Monoid, Eq, Empty, Show, ShowType, Read
+  case class ISB(i: Int, s: String, b: Boolean) derives Monoid, Eq, Empty, Show, ShowType, Read, Merge
+
+  case class Config(name: String, count: Option[Int], label: Option[String]) derives Merge
 
   case class Box[A](x: A) derives Monoid, Eq, Show, ShowType, Read, Functor, Return, Ord, Traverse, Foldable
 

--- a/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/deriving.scala
@@ -292,6 +292,18 @@ class DerivationTests:
     assert(diff(SomeInt(1), NoneInt) == "different variants")
 
   @Test
+  def merge(): Unit =
+    val v0 = Merge[ISB]
+    assert(v0.merge(ISB(1, "foo", true), ISB(1, "foo", true)) == Some(ISB(1, "foo", true)))
+    assert(v0.merge(ISB(1, "foo", true), ISB(2, "foo", true)) == None)
+    assert(v0.merge(ISB(1, "foo", true), ISB(1, "bar", true)) == None)
+
+    val v1 = Merge[Config]
+    assert(v1.merge(Config("a", Some(1), None), Config("a", None, Some("x"))) == Some(Config("a", Some(1), Some("x"))))
+    assert(v1.merge(Config("a", Some(1), None), Config("a", Some(2), None)) == None)
+    assert(v1.merge(Config("a", None, None), Config("a", None, Some("x"))) == Some(Config("a", None, Some("x"))))
+
+  @Test
   def functorK(): Unit =
     val v0 = FunctorK[Order]
     assert(v0.mapK(Order[OptionD](Given("Epoisse"), Default(10)))(OptionD.fold) == Order[Id]("Epoisse", 10))

--- a/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
+++ b/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala
@@ -236,6 +236,43 @@ object Traverse:
 
   inline def derived[F[_]](using gen: K1.Generic[F]): Traverse[F] = traverseGen
 
+trait Merge[A]:
+  def merge(x: A, y: A): Option[A]
+
+object Merge:
+  inline def apply[A](using ma: Merge[A]): ma.type = ma
+
+  given Merge[Int] with
+    def merge(x: Int, y: Int): Option[Int] =
+      if x == y then Some(x) else None
+
+  given Merge[String] with
+    def merge(x: String, y: String): Option[String] =
+      if x == y then Some(x) else None
+
+  given Merge[Boolean] with
+    def merge(x: Boolean, y: Boolean): Option[Boolean] =
+      if x == y then Some(x) else None
+
+  given [A](using ma: Merge[A]): Merge[Option[A]] with
+    def merge(x: Option[A], y: Option[A]): Option[Option[A]] = (x, y) match
+      case (Some(a), Some(b)) => ma.merge(a, b).map(Some(_))
+      case (Some(_), None) => Some(x)
+      case (None, Some(_)) => Some(y)
+      case (None, None) => Some(None)
+
+  given product[T](using inst: K0.ProductInstances[Merge, T]): Merge[T] with
+    private val map: MapF[Option] = [a, b] => (oa: Option[a], f: a => b) => oa.map(f)
+    private val pure: Pure[Option] = [a] => (x: a) => Some(x)
+    private val ap: Ap[Option] = [a, b] => (of: Option[a => b], oa: Option[a]) => of.flatMap(f => oa.map(f))
+
+    def merge(x: T, y: T): Option[T] =
+      inst.traverse2[Option](x, y)(map)(pure)(ap)(
+        [t] => (m: Merge[t], tx: t, ty: t) => m.merge(tx, ty)
+      )
+
+  inline def derived[T](using gen: K0.ProductGeneric[T]): Merge[T] = product
+
 trait Optional[F[_]]:
   def headOption[A](fa: F[A]): Option[A]
 


### PR DESCRIPTION
traverse2 is basically an effectful version of map2.

Internally we use ZippedProdcut to piggy back on the existing traverse
implementation.
